### PR TITLE
Added useNativeDriver to Animated.timing

### DIFF
--- a/src/KeyboardSpacer/KeyboardSpacer.js
+++ b/src/KeyboardSpacer/KeyboardSpacer.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Dimensions, Animated, Keyboard } from 'react-native';
 
-const KeyboardSpacer = ({ space }) => {
+const KeyboardSpacer = ({ space, isUsingNativeDriver }) => {
   const [state, setState] = useState({
     keyboardHeight: 0,
   });
@@ -26,6 +26,7 @@ const KeyboardSpacer = ({ space }) => {
     Animated.timing(imageHeight, {
       duration: 240,
       toValue: e.endCoordinates.height - space,
+      useNativeDriver: isUsingNativeDriver,
     }).start();
   }
 
@@ -33,6 +34,7 @@ const KeyboardSpacer = ({ space }) => {
     Animated.timing(imageHeight, {
       duration: 240,
       toValue: 0,
+      useNativeDriver: isUsingNativeDriver,
     }).start();
   }
 


### PR DESCRIPTION
Prompt issue from iPhone 13
```
Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false
```